### PR TITLE
Handle CONNECTION_ALLOCATED in ngx_pq_event_handler

### DIFF
--- a/config
+++ b/config
@@ -1,5 +1,5 @@
 ngx_addon_name=ngx_pq_module
-ngx_feature_path="`pg_config --includedir` `pg_config --includedir-server`"
+ngx_feature_path="`pg_config --includedir` `pg_config --includedir-server` `pg_config --pkgincludedir`"
 
 NGX_PQ_SRCS=$ngx_addon_dir/ngx_pq_module.c
 

--- a/ngx_pq_module.c
+++ b/ngx_pq_module.c
@@ -849,6 +849,7 @@ static void ngx_pq_event_handler(ngx_http_request_t *r, ngx_http_upstream_t *u) 
             goto ret;
         case CONNECTION_SETENV: ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "CONNECTION_SETENV"); break;
         case CONNECTION_SSL_STARTUP: ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "CONNECTION_SSL_STARTUP"); break;
+        case CONNECTION_ALLOCATED: ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "CONNECTION_ALLOCATED"); break;
         case CONNECTION_STARTED: ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "CONNECTION_STARTED"); break;
     }
     if (c->read->timedout || c->write->timedout) return ngx_http_upstream_next_my(r, u, NGX_HTTP_UPSTREAM_FT_TIMEOUT);


### PR DESCRIPTION
One more compilation error:
`../git/ngx_pq_module/ngx_pq_module.c: In function ‘ngx_pq_event_handler’:
../git/ngx_pq_module/ngx_pq_module.c:835:5: error: enumeration value ‘CONNECTION_ALLOCATED’ not handled in switch [-Werror=switch]
  835 |     switch (PQstatus(s->conn)) {
      |     ^~~~~~
`