### PR TITLE
Add binary output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ location =/postgres {
 ```
 pq_execute
 -------------
-* Syntax: **pq_execute** *$query_name* [ *$argument_value* ] [ output=*csv* | output=*plain* | output=*value* | output=*$variable* ]
+* Syntax: **pq_execute** *$query_name* [ *$argument_value* ] [ output=*csv* | output=*plain* | output=*value* | output=*binary* | output=*$variable* ]
 * Default: --
 * Context: location, if in location, upstream
 
-Sets $query_name (nginx variables allowed), optional (several) $argument_value (nginx variables allowed) and output csv/plain/value (location only, no nginx variables allowed) or $variable (create nginx variable) for execute:
+Sets $query_name (nginx variables allowed), optional (several) $argument_value (nginx variables allowed) and output csv/plain/value/binary (location only, no nginx variables allowed) or $variable (upstream only, create nginx variable) for execute:
 ```nginx
 location =/postgres {
     pq_execute $query string $argument output=plain; # execute query with name $query and two arguments (first argument is string and second argument is taken from $argument variable) and plain output type
@@ -149,11 +149,11 @@ location =/postgres {
 ```
 pq_query
 -------------
-* Syntax: **pq_query** *sql* [ *$argument_value* | *$argument_value*::*$argument_oid* ] [ output=*csv* | output=*plain* | output=*value* | output=*$variable* ]
+* Syntax: **pq_query** *sql* [ *$argument_value* | *$argument_value*::*$argument_oid* ] [ output=*csv* | output=*plain* | output=*value* | output=*binary* | output=*$variable* ]
 * Default: --
 * Context: location, if in location, upstream
 
-Sets sql (named only nginx variables allowed as identifier only), optional (several) $argument_value (nginx variables allowed), $argument_oid (nginx variables allowed) and output csv/plain/value (location only, no nginx variables allowed) or $variable (create nginx variable) for prepare and execute:
+Sets sql (named only nginx variables allowed as identifier only), optional (several) $argument_value (nginx variables allowed), $argument_oid (nginx variables allowed) and output csv/plain/value/binary (location only, no nginx variables allowed) or $variable (upstream only, create nginx variable) for prepare and execute:
 ```nginx
 location =/postgres {
     pq_pass postgres; # upstream is postgres


### PR DESCRIPTION
Option for output binary data from BYTEA fields.
For example
```
location ~ ^/article-icon/(?<article>[0-9]+)/ {
  default_type  image/jpeg;
  pq_pass       db;
  pq_query      "SELECT icon FROM article WHERE id = $1" $article output=binary;
}
```